### PR TITLE
feat: finalizeRequest

### DIFF
--- a/Campaign.sol
+++ b/Campaign.sol
@@ -14,6 +14,7 @@ contract Campaign {
     address public manager;
     uint256 public minimumContribution;
     mapping(address => bool) public approvers;
+    uint256 public approversCount;
 
     modifier restricted() {
         require(msg.sender == manager);
@@ -29,6 +30,7 @@ contract Campaign {
         require(msg.value > minimumContribution);
 
         approvers[msg.sender] = true;
+        approversCount++;
     }
 
     function createRequest(
@@ -55,5 +57,15 @@ contract Campaign {
 
         request.approvals[msg.sender] = true;
         request.approvalCount++;
+    }
+
+    function finalizeRequest(uint256 index) public restricted {
+        Request storage request = requests[index];
+
+        require(request.approvalCount > (approversCount / 2));
+        require(!request.complete);
+
+        request.recipient.transfer(request.value);
+        request.complete = true;
     }
 }


### PR DESCRIPTION
finalizeRequest function requires the request to not be complete and that the approvalCount is over half of the approversCount. After that it will tranfer the request.value which was set during the contract creation

closes #14