### PR TITLE
feat: campaign factory

### DIFF
--- a/Campaign.sol
+++ b/Campaign.sol
@@ -1,5 +1,18 @@
 pragma solidity ^0.4.17;
 
+contract CampaignFactory {
+    address[] public deployedCampaigns;
+
+    function createCampaign(uint256 minimum) public {
+        address newCampaign = new Campaign(minimum, msg.sender);
+        deployedCampaigns.push(newCampaign);
+    }
+
+    function getDeployedCampaign() public view returns (address[]) {
+        return deployedCampaigns;
+    }
+}
+
 contract Campaign {
     struct Request {
         string description;
@@ -21,8 +34,8 @@ contract Campaign {
         _;
     }
 
-    function Campaign(uint256 minimum) public {
-        manager = msg.sender;
+    function Campaign(uint256 minimum, address creator) public {
+        manager = creator;
         minimumContribution = minimum;
     }
 


### PR DESCRIPTION
campaignFactory creates an additional contract that is used to deploy our Campaign contracts without requiring a user to deploy and potentially modifiy our contract. Also refactored Campaign contract to include a parameter for the msg.sender's address

closes #16