### PR TITLE
feat: account campaign test

### DIFF
--- a/test/Campaign.test.js
+++ b/test/Campaign.test.js
@@ -35,4 +35,17 @@ describe("Campaigns", () => {
     assert.ok(factory.options.address);
     assert.ok(campaign.options.address);
   });
+
+  it("marks caller as the campaign manager", async () => {
+    const manager = await campaign.methods.manager().call();
+    assert.equal(accounts[0], manager);
+  });
+
+  it("allows people to contribute money and marks them as approvers", async () => {
+    await campaign.methods
+      .contribute()
+      .send({ value: "200", from: accounts[1] });
+    const isContributor = await campaign.methods.approvers(accounts[1]).call();
+    assert(isContributor);
+  });
 });


### PR DESCRIPTION
tests associated to both that the address that uses the factory is the manager of the created campaign

test that allows a user to contribute to the project and is added to the approvers mapping

closes #29, closes #30