### PR TITLE
feat: end to end test

### DIFF
--- a/test/Campaign.test.js
+++ b/test/Campaign.test.js
@@ -73,4 +73,31 @@ describe("Campaigns", () => {
 
     assert.equal("Buy batteries", request.description);
   });
+
+  it("processes request", async () => {
+    await campaign.methods.contribute().send({
+      from: accounts[0],
+      value: web3.utils.toWei("10", "ether"),
+    });
+
+    await campaign.methods
+      .createRequest("A", web3.utils.toWei("5", "ether"), accounts[1])
+      .send({ from: accounts[0], gas: "1000000" });
+
+    await campaign.methods.approveRequest(0).send({
+      from: accounts[0],
+      gas: "1000000",
+    });
+
+    await campaign.methods.finalizeRequest(0).send({
+      from: accounts[0],
+      gas: "1000000",
+    });
+
+    let balance = await web3.eth.getBalance(accounts[1]);
+    balance = web3.utils.fromWei(balance, "ether");
+    balance = parseFloat(balance);
+
+    assert(balance > 104);
+  });
 });


### PR DESCRIPTION
test has accounts[0] contribute ether to the campaign
then creates a request that will give 5 ether to accounts[1]
account[0] approves the requests and then calls the request
account[0] finalizes the request and then we check the balance of accounts[1]
we know that that account should have around 104ether associated to it but the current setup doesn't allow us to reset the ganache instance easily

closes #36