### PR TITLE
feat: web3 and contract connection

### DIFF
--- a/ethereum/factory.js
+++ b/ethereum/factory.js
@@ -1,0 +1,10 @@
+import web3 from "./web3";
+import CampaignFactory from "./build/CampaignFactory.json";
+import { deployedAddress } from "../secrets";
+
+const instance = new web3.eth.Contract(
+  JSON.parse(CampaignFactory.interface),
+  deployedAddress
+);
+
+export default instance;

--- a/ethereum/web3.js
+++ b/ethereum/web3.js
@@ -1,0 +1,7 @@
+import Web3 from "web3";
+
+window.ethereum.request({ method: "eth_requestAccounts" });
+
+const web3 = new Web3(window.ethereum);
+
+export default web3;


### PR DESCRIPTION
used web3.js to connect to metamask, note that this assumes that metamask has already injected code to our website, will need to fix this later.

factory.js creates a template that we will use that already connects to our deployed contract of the factory using the address we supply

closes #43, closes #44