### PR TITLE
fix: serverside rendering

### DIFF
--- a/ethereum/web3.js
+++ b/ethereum/web3.js
@@ -1,7 +1,14 @@
 import Web3 from "web3";
+import { infuraLink } from "./secrets";
 
-window.ethereum.request({ method: "eth_requestAccounts" });
+let web3;
 
-const web3 = new Web3(window.ethereum);
+if (typeof window !== "undefined" && typeof window.ethereum !== "undefined") {
+  window.ethereum.request({ method: "eth_requestAccounts" });
+  web3 = new Web3(window.ethereum);
+} else {
+  const provider = new Web3.providers.HttpProvider(infuraLink);
+  web3 = new Web3(provider);
+}
 
 export default web3;


### PR DESCRIPTION
nextjs uses serverside rendering logic was added to the web3.js page to check 1) if the script is on a browser or a server and 2) to check if the user is running metamask, otherwise it will create a provider to use and grab the data we want

closes #48