### PR TITLE
feat: rendering campaign information

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,16 @@
+import React, { Component } from "react";
+import factory from "../ethereum/factory";
+
+class CampaignIndex extends Component {
+  static async getInitialProps() {
+    const campaigns = await factory.methods.getDeployedCampaigns().call();
+
+    return { campaigns: campaigns };
+  }
+
+  render() {
+    return <div>{this.props.campaigns[0]}</div>;
+  }
+}
+
+export default CampaignIndex;


### PR DESCRIPTION
uses the instance of the factory that we detailed in the factory.js file to then render the address of the first campaign on our page

Nextjs uses getInitialProps with the static keyword to run that function prior to rendering any of the class component.

closes #47