### PR TITLE
fix: css rendering

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -22,7 +22,15 @@ class CampaignIndex extends Component {
   }
 
   render() {
-    return <div>{this.renderCampaigns()}</div>;
+    return (
+      <div>
+        <link
+          rel="stylesheet"
+          href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.12/semantic.min.css"
+        ></link>
+        {this.renderCampaigns()}
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
fixed css rendering as NextJS does not support modular css, included basic link tag to the react component to show styling

closes #54