### PR TITLE
feat: layout setup

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+const Layout = (props) => {
+  return (
+    <div>
+      <h1>I'm a header</h1>
+      {props.children}
+      <h1>I'm a footer</h1>
+    </div>
+  );
+};
+
+export default Layout;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { Card, Button } from "semantic-ui-react";
 import factory from "../ethereum/factory";
+import Layout from "../components/Layout";
 
 class CampaignIndex extends Component {
   static async getInitialProps() {
@@ -23,15 +24,17 @@ class CampaignIndex extends Component {
 
   render() {
     return (
-      <div>
-        <link
-          rel="stylesheet"
-          href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.12/semantic.min.css"
-        ></link>
-        <h3>Open Campaigns</h3>
-        {this.renderCampaigns()}
-        <Button content="Create Campaign" icon="add" primary />
-      </div>
+      <Layout>
+        <div>
+          <link
+            rel="stylesheet"
+            href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.12/semantic.min.css"
+          ></link>
+          <h3>Open Campaigns</h3>
+          {this.renderCampaigns()}
+          <Button content="Create Campaign" icon="add" primary />
+        </div>
+      </Layout>
     );
   }
 }


### PR DESCRIPTION
in a separate directory created a Layout page that will house the duplicate code, used the props.children portion of React to specify where exactly we want to place the subsequent code, used template code to check exactly where the components will render the header and footer inside the nextjs page

closes #59