### PR TITLE
style: container and two columns

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -3,7 +3,7 @@ import { Menu } from "semantic-ui-react";
 
 const Header = () => {
   return (
-    <Menu>
+    <Menu style={{ marginTop: "10px" }}>
       <Menu.Item>KickCoin</Menu.Item>
 
       <Menu.Menu position="right">

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,12 +1,13 @@
 import React from "react";
+import { Container } from "semantic-ui-react";
 import Header from "./Header";
 
 const Layout = (props) => {
   return (
-    <div>
+    <Container>
       <Header />
       {props.children}
-    </div>
+    </Container>
   );
 };
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -31,8 +31,13 @@ class CampaignIndex extends Component {
             href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.12/semantic.min.css"
           ></link>
           <h3>Open Campaigns</h3>
+          <Button
+            floated="right"
+            content="Create Campaign"
+            icon="add"
+            primary
+          />
           {this.renderCampaigns()}
-          <Button content="Create Campaign" icon="add" primary />
         </div>
       </Layout>
     );


### PR DESCRIPTION
added container component from semantic-ui to the Layout.js file to prevent interior components from rendering across the entire screen, also added custom margin property to the header to bring it off of the top of the screen

finally changed the position of the button in its render position and added the custom floated property to make it render on the right side, this created teh two colomn layout

closes #64, closes #65