### PR TITLE
feat: accessing campaign information

### DIFF
--- a/ethereum/campaign.js
+++ b/ethereum/campaign.js
@@ -1,0 +1,8 @@
+import web3 from "./web3";
+import Campaign from "./build/Campaign.json";
+
+const instance = (address) => {
+  return new web3.eth.Contract(JSON.parse(Campaign.interface), address);
+};
+
+export default instance;

--- a/pages/campaigns/show.js
+++ b/pages/campaigns/show.js
@@ -1,8 +1,23 @@
 import React, { Component } from "react";
-
+import Layout from "../../components/Layout";
+import Campaign from "../../ethereum/campaign";
 class CampaignShow extends Component {
+  static async getInitialProps(props) {
+    const campaign = Campaign(props.query.address);
+
+    const summary = await campaign.methods.getSummary().call();
+
+    console.log(summary);
+
+    return {};
+  }
+
   render() {
-    return <h3>Campaign Show</h3>;
+    return (
+      <Layout>
+        <h3>Campaign Show</h3>
+      </Layout>
+    );
   }
 }
 


### PR DESCRIPTION
added an instance file in the ethereum directory to reduce duplicate code in the future for accessing a specific campaign via its address

updated show.js to include a getInitialProps that will call the method on the instance to return all the values that we will want to use to display information on the single campaign page

closes #98