### PR TITLE
feat: add requests

### DIFF
--- a/pages/campaigns/requests/index.js
+++ b/pages/campaigns/requests/index.js
@@ -1,8 +1,26 @@
 import React, { Component } from "react";
+import { Button } from "semantic-ui-react";
+import { Link } from "../../../routes";
+import Layout from "../../../components/Layout";
 
 class RequestIndex extends Component {
+  static async getInitialProps(props) {
+    const { address } = props.query;
+
+    return { address };
+  }
+
   render() {
-    return <h3>Request List</h3>;
+    return (
+      <Layout>
+        <h3>Requests</h3>
+        <Link route={`/campaigns/${this.props.address}/requests/new`}>
+          <a>
+            <Button primary>Add Request</Button>
+          </a>
+        </Link>
+      </Layout>
+    );
   }
 }
 

--- a/pages/campaigns/requests/new.js
+++ b/pages/campaigns/requests/new.js
@@ -1,0 +1,61 @@
+import React, { Component } from "react";
+import { Form, Button, Message, Input } from "semantic-ui-react";
+import Campaign from "../../../ethereum/campaign";
+import web3 from "../../../ethereum/web3";
+import { Link, Router } from "../../../routes";
+import Layout from "../../../components/Layout";
+
+class RequestNew extends Component {
+  state = {
+    value: "",
+    description: "",
+    recipient: "",
+  };
+
+  static async getInitialProps(props) {
+    const { address } = props.query;
+
+    return { address };
+  }
+
+  render() {
+    return (
+      <Layout>
+        <h3>Create a Request</h3>
+        <Form>
+          <Form.Field>
+            <label>Description</label>
+            <Input
+              value={this.state.description}
+              onChange={(event) =>
+                this.setState({ description: event.target.value })
+              }
+            />
+          </Form.Field>
+
+          <Form.Field>
+            <label>Value in Ether</label>
+            <Input
+              value={this.state.value}
+              onChange={(event) => this.setState({ value: event.target.value })}
+            />
+          </Form.Field>
+
+          <Form.Field>
+            <label>Recipient</label>
+            <Input
+              value={this.state.recipient}
+              onChange={(event) =>
+                this.setState({ recipient: event.target.value })
+              }
+            />
+          </Form.Field>
+
+          <Button primary>Create!</Button>
+        </Form>
+      </Layout>
+    );
+  }
+}
+
+export default RequestNew;

--- a/routes.js
+++ b/routes.js
@@ -3,6 +3,7 @@ const routes = require("next-routes")();
 routes
   .add("/campaigns/new", "/campaigns/new")
   .add("/campaigns/:address", "/campaigns/show")
-  .add("/campaigns/:address/requests", "/campaigns/requests/index");
+  .add("/campaigns/:address/requests", "/campaigns/requests/index")
+  .add("/campaigns/:address/requests/new", "/campaigns/requests/new");
 
 module.exports = routes;


### PR DESCRIPTION
added the button and route to the requests page to navigate to the new requests page. Inside the new requests page added a form with onChange handlers to manage state for our inputs to be able to use them in our ethereum method calls

closes #117, closes #118