### PR TITLE
feat: new requests onSubmit

### DIFF
--- a/pages/campaigns/requests/new.js
+++ b/pages/campaigns/requests/new.js
@@ -18,11 +18,25 @@ class RequestNew extends Component {
     return { address };
   }
 
+  onSubmit = async (event) => {
+    event.preventDefault();
+
+    const campaign = Campaign(this.props.address);
+    const { description, value, recipient } = this.state;
+
+    try {
+      const accounts = await web3.eth.getAccounts();
+      await campaign.methods
+        .createRequest(description, web3.utils.toWei(value, "ether"), recipient)
+        .send({ from: accounts[0] });
+    } catch (error) {}
+  };
+
   render() {
     return (
       <Layout>
         <h3>Create a Request</h3>
-        <Form>
+        <Form onSubmit={this.onSubmit}>
           <Form.Field>
             <label>Description</label>
             <Input


### PR DESCRIPTION
created an onSubmit handler for the new requests page that uses an the campaign instance to call our method createRequets and uses the state to manage the request from there

closes #120