### PR TITLE
feat: error handling new requests

### DIFF
--- a/pages/campaigns/requests/new.js
+++ b/pages/campaigns/requests/new.js
@@ -10,6 +10,8 @@ class RequestNew extends Component {
     value: "",
     description: "",
     recipient: "",
+    loading: false,
+    errorMessage: "",
   };
 
   static async getInitialProps(props) {
@@ -21,6 +23,8 @@ class RequestNew extends Component {
   onSubmit = async (event) => {
     event.preventDefault();
 
+    this.setState({ loading: true, errorMessage: "" });
+
     const campaign = Campaign(this.props.address);
     const { description, value, recipient } = this.state;
 
@@ -29,14 +33,23 @@ class RequestNew extends Component {
       await campaign.methods
         .createRequest(description, web3.utils.toWei(value, "ether"), recipient)
         .send({ from: accounts[0] });
-    } catch (error) {}
+
+      Router.pushRoute(`/campaigns/${this.props.address}/requests`);
+    } catch (error) {
+      this.setState({ errorMessage: error.message });
+    }
+
+    this.setState({ loading: false });
   };
 
   render() {
     return (
       <Layout>
+        <Link route={`/campaigns/${this.props.address}/requests`}>
+          <a>Back</a>
+        </Link>
         <h3>Create a Request</h3>
-        <Form onSubmit={this.onSubmit}>
+        <Form onSubmit={this.onSubmit} error={!!this.state.errorMessage}>
           <Form.Field>
             <label>Description</label>
             <Input
@@ -65,7 +78,11 @@ class RequestNew extends Component {
             />
           </Form.Field>
 
-          <Button primary>Create!</Button>
+          <Message error header="Oops" content={this.state.errorMessage} />
+
+          <Button primary loading={this.state.loading}>
+            Create!
+          </Button>
         </Form>
       </Layout>
     );


### PR DESCRIPTION
added error message and button spinner to the create a request page, same as previous implementations by using state to manage the loading and error message. Also added in redirecting after the successful completion of a transaction back to the requests page, and finally added a back link to the create a requests page

closes #122, closes #123