### PR TITLE
feat: request getter

### DIFF
--- a/pages/campaigns/requests/index.js
+++ b/pages/campaigns/requests/index.js
@@ -2,12 +2,23 @@ import React, { Component } from "react";
 import { Button } from "semantic-ui-react";
 import { Link } from "../../../routes";
 import Layout from "../../../components/Layout";
+import Campaign from "../../../ethereum/campaign";
 
 class RequestIndex extends Component {
   static async getInitialProps(props) {
     const { address } = props.query;
+    const campaign = Campaign(address);
+    const requestCount = await campaign.methods.getRequestsCount().call();
 
-    return { address };
+    const requests = await Promise.all(
+      Array(parseInt(requestCount))
+        .fill()
+        .map((element, index) => {
+          return campaign.methods.requests(index).call();
+        })
+    );
+
+    return { address, requests, requestCount };
   }
 
   render() {


### PR DESCRIPTION
wrote a Promise.all function that will fill an array with the total numeber of requests that we associate with the campaign (requestCount) and then use a map function to get each request by its index in the array. Added requests, and requestCount to the props

closes #126